### PR TITLE
If a user calls authenticateAndGetUserAsync() multiple times before i…

### DIFF
--- a/demo/demo1.html
+++ b/demo/demo1.html
@@ -8,6 +8,7 @@
             roles="{{roles}}"></lss-user-manager>
         <paper-button raised on-tap="logoutClicked">Logout</paper-button>
         <paper-button raised on-tap="getUserObject">GetUserAsync()</paper-button>
+        <paper-button raised on-tap="callMultiple">Call GetUserAsync Multiple Times</paper-button>
         <h2>name: [[name]]</h2>
         <h2>firstName: [[firstName]]</h2>
         <h2>shouldValidateOnLoad: [[shouldLoad]]</h2>
@@ -42,6 +43,11 @@
                 this.$.manager.authenticateAndGetUserAsync().then(function (user) {
                     console.log(user);
                 });
+            },
+            callMultiple: function (e) {
+                this.$.manager.authenticateAndGetUserAsync().then(function () { console.log("1 done"); });
+                this.$.manager.authenticateAndGetUserAsync().then(function () { console.log("2 done"); });
+                this.$.manager.authenticateAndGetUserAsync().then(function () { console.log("3 done"); });
             }
         });
     </script>

--- a/lss-user-manager.js
+++ b/lss-user-manager.js
@@ -271,7 +271,6 @@ var LssUserManager = (function (_super) {
                 switch (_a.label) {
                     case 0:
                         if (this.getUserAsyncPromise != null) {
-                            console.log("reused getUserAsyncPromise");
                             return [2 /*return*/, this.getUserAsyncPromise];
                         }
                         _a.label = 1;

--- a/lss-user-manager.js
+++ b/lss-user-manager.js
@@ -51,6 +51,7 @@ var LssUserManager = (function (_super) {
         var _this = _super.apply(this, arguments) || this;
         _this.loginUrl = "https://login.leavitt.com/oauth/";
         _this.localStorageKey = "LgUser";
+        _this.getUserAsyncPromise = null;
         return _this;
     }
     LssUserManager.prototype.attached = function () {
@@ -265,16 +266,25 @@ var LssUserManager = (function (_super) {
     ;
     LssUserManager.prototype.authenticateAndGetUserAsync = function () {
         return __awaiter(this, void 0, void 0, function () {
-            var user, error_3;
+            var getUserAsyncPromise, user, error_3;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
-                        _a.trys.push([0, 2, , 3]);
-                        return [4 /*yield*/, this.getUserAsync()];
+                        if (this.getUserAsyncPromise != null) {
+                            console.log("reused getUserAsyncPromise");
+                            return [2 /*return*/, this.getUserAsyncPromise];
+                        }
+                        _a.label = 1;
                     case 1:
-                        user = _a.sent();
-                        return [2 /*return*/, Promise.resolve(user)];
+                        _a.trys.push([1, 3, , 4]);
+                        getUserAsyncPromise = this.getUserAsync();
+                        this.getUserAsyncPromise = getUserAsyncPromise;
+                        return [4 /*yield*/, this.getUserAsyncPromise];
                     case 2:
+                        user = _a.sent();
+                        this.getUserAsyncPromise = null;
+                        return [2 /*return*/, getUserAsyncPromise];
+                    case 3:
                         error_3 = _a.sent();
                         if (error_3 === "Not authenticated") {
                             this.redirectToLogin(document.location.href);
@@ -286,7 +296,7 @@ var LssUserManager = (function (_super) {
                                 })];
                         }
                         return [2 /*return*/, Promise.resolve(null)];
-                    case 3: return [2 /*return*/];
+                    case 4: return [2 /*return*/];
                 }
             });
         });

--- a/lss-user-manager.ts
+++ b/lss-user-manager.ts
@@ -245,7 +245,6 @@ class LssUserManager extends polymer.Base {
 
     async authenticateAndGetUserAsync(): Promise<User | null> {
         if (this.getUserAsyncPromise != null) {
-            console.log("reused getUserAsyncPromise")
             return this.getUserAsyncPromise;
         }
 

--- a/lss-user-manager.ts
+++ b/lss-user-manager.ts
@@ -241,10 +241,20 @@ class LssUserManager extends polymer.Base {
         return Promise.resolve(null);
     };
 
+    getUserAsyncPromise: Promise<User> = null;
+
     async authenticateAndGetUserAsync(): Promise<User | null> {
+        if (this.getUserAsyncPromise != null) {
+            console.log("reused getUserAsyncPromise")
+            return this.getUserAsyncPromise;
+        }
+
         try {
-            var user = await this.getUserAsync();
-            return Promise.resolve(user);
+            var getUserAsyncPromise = this.getUserAsync();
+            this.getUserAsyncPromise = getUserAsyncPromise;
+            var user = await this.getUserAsyncPromise;
+            this.getUserAsyncPromise = null;
+            return getUserAsyncPromise;
         } catch (error) {
             if (error === "Not authenticated") {
                 this.redirectToLogin(document.location.href);


### PR DESCRIPTION
…t has completed, they will be returned the promise from their very first call as to prevent running the login logic multiple times which could cause unintended redirects.